### PR TITLE
Fix: Grant write permissions to workflows (#3)

### DIFF
--- a/.github/workflows/sn_intel.yml
+++ b/.github/workflows/sn_intel.yml
@@ -21,6 +21,7 @@ concurrency:
 
 permissions:
   contents: write
+  issues: write
 
 jobs:
   intel:

--- a/.github/workflows/sn_ledger.yml
+++ b/.github/workflows/sn_ledger.yml
@@ -21,6 +21,7 @@ concurrency:
 
 permissions:
   contents: write
+  issues: write
 
 jobs:
   snapshot:

--- a/.github/workflows/trending.yml
+++ b/.github/workflows/trending.yml
@@ -14,6 +14,7 @@ concurrency:
 
 permissions:
   contents: write
+  issues: write
 
 jobs:
   scan:


### PR DESCRIPTION
Added 'issues: write' permissions to sn_intel, sn_ledger, and trending workflows to allow automated issue creation and management.