### PR TITLE
fix: increase LOOKBACK_HOURS to 48 and add Stacker_Sports sub to radar (Bounty #43)

### DIFF
--- a/scripts/sn_opportunity_radar.mjs
+++ b/scripts/sn_opportunity_radar.mjs
@@ -13,11 +13,11 @@ import fs from 'node:fs';
 import path from 'node:path';
 
 const BASE = 'https://stacker.news';
-const SUBS = ['bitcoin', 'jobs', 'meta', 'tech', 'AGITHON'];
+const SUBS = ["bitcoin", "jobs", "meta", "tech", "AGITHON", "Stacker_Sports"];
 const SORTS = ['recent'];
 const MIN_BOUNTY_SATS = 100;
 const MAX_COMMENTS_FOR_LOW_COMP = 5;
-const LOOKBACK_HOURS = 24;
+const LOOKBACK_HOURS = 48;
 
 // SN GraphQL items query — 只取需要欄位降低 payload
 // 2026-05-03 schema 升級：加 user.since/nitems 供 parent 篩選硬規則 #3 使用


### PR DESCRIPTION
## Summary
- Increased LOOKBACK_HOURS from 24 to 48 to allow older items to be considered (the OPEN_BOUNTY item is ~34 hours old)
- Added "Stacker_Sports" to the SUBS list so the radar scans that sub
- This ensures the OPEN_BOUNTY item (id 1490676) is captured and tagged with OPEN_BOUNTY

## Changes
- Modified `scripts/sn_opportunity_radar.mjs`:
  - Changed LOOKBACK_HOURS to 48
  - Added "Stacker_Sports" to SUBS array

## Test Plan
- Ran the script with --json and verified that item 1490676 appears with OPEN_BOUNTY tag
- Verified that the item's ageHours is about 34.3, which is less than 48

Closes #43

USDT (TRC20): TWPjPKBMT6yGgngQqBNJttg6yuteyQroXT