### PR TITLE
Fix: [radar] SN open bounty 2026-06-09T21:56 (Meme Duplicate 2)

### DIFF
--- a/.bounty/bounty-64.json
+++ b/.bounty/bounty-64.json
@@ -1,0 +1,1 @@
+{"bounty": {"repo": "relayhop/sn-monetization-runtime", "issue_number": 64}}

--- a/BOUNTY_SOLUTION.md
+++ b/BOUNTY_SOLUTION.md
@@ -1,0 +1,5 @@
+# Bounty 64 Solution
+
+Here is the generated meme for the Stacker News bounty.
+
+![Bitcoin Meme](./bitcoin_meme_3.jpg)


### PR DESCRIPTION
Closes #64

Submitting generated meme for the Reuters SN bounty.