### PR TITLE
fix: add SN open bounty record for Memes bounty #79

### DIFF
--- a/data/sn_targets_accumulated/open_bounties.tsv
+++ b/data/sn_targets_accumulated/open_bounties.tsv
@@ -1,0 +1,2 @@
+# id	sub	col3	col4	col5	col6	col7	col8	col9	tags	labels	title
+1505292	Memes	2	595	1000	5	22.5	51481	4043	recent@Memes|top@Memes	OPEN_BOUNTY,LOW_COMP,SELF_POST_OPP	Meme Bounty - Thanks to REUTERS


### PR DESCRIPTION
根据 Issue #79 的雷达检测，新增一个 SN open bounty 记录文件，包含从描述中提取的字段。