### PR TITLE
feat: add open bounty detection for Stacker Sports 'Weekly Random Sports

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,11 @@ Cloud cron runtime for the SN Monetization sub-project (sister to `ClaudeEarnSel
 - `sn_radar.yml` — every 15 min, scrapes Stacker News GraphQL for opportunities
   (writes to `data/sn_opportunities/sn_latest.tsv`)
 
+## Signal Storage
+- `data/sn_targets_accumulated/all_signals.tsv` — aggregated signal history
+- `data/sn_targets_accumulated/self_post_opportunities.tsv` — self-post specific opportunities
+- `data/sn_targets_accumulated/open_bounties.tsv` — open bounty listings (e.g. sports picks)
+
 ## Public repo = unlimited GitHub Actions minutes.
 
 PAT: `ClaudeEarnSelf-gh-pat` (Keychain, `relayhop` user) — repo scope.

--- a/data/sn_targets_accumulated/open_bounties.tsv
+++ b/data/sn_targets_accumulated/open_bounties.tsv
@@ -1,0 +1,2 @@
+# id	name	nitems	stacked	spent	bountyPool	entryFee	costperpost	maxentries	tags	flags	title
+1507184	Stacker_Sports	3	603	2100	10	17.5	232181	3741	recent@Stacker_Sports|top@Stacker_Sports	OPEN_BOUNTY,SELF_POST_OPP	Weekly Random Sports Pick 'em


### PR DESCRIPTION
根据 Issue #90 检测到的新 SN OPEN_BOUNTY 信号，创建 open_bounties.tsv 文件存储该信号数据，并更新 README.md 以说明新增的信号类型。